### PR TITLE
Refactor System.Text.Json dependency

### DIFF
--- a/src/Dax.Formatter/Dax.Formatter.csproj
+++ b/src/Dax.Formatter/Dax.Formatter.csproj
@@ -45,8 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.11" Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.0'" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Remove `System.Text.Json` dependency for .NET 6/8 targets.
- Update `System.Text.Json` to 8.0.5 for .NET Standard target.