### PR TITLE
Switch to new api.daxformatter.com endpoint and remove redirect handling

### DIFF
--- a/src/Dax.Formatter/Client/Http/DaxFormatterHttpClient.cs
+++ b/src/Dax.Formatter/Client/Http/DaxFormatterHttpClient.cs
@@ -1,9 +1,8 @@
-﻿namespace Dax.Formatter.Client.Http
+namespace Dax.Formatter.Client.Http
 {
     using Dax.Formatter.Models;
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
@@ -19,7 +18,6 @@
         private const int DaxFormatterTimeoutSeconds = 60;
 
         private readonly JsonSerializerOptions _serializerOptions;
-        private readonly SemaphoreSlim _formatSemaphore;
         private readonly HttpClient _httpClient;
         private readonly string? _application;
         private readonly string? _version;
@@ -36,8 +34,6 @@
             _httpClient.DefaultRequestHeaders.Clear();
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNamesApplicationJson));
             _httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue(nameof(DecompressionMethods.GZip)));
-            
-            _formatSemaphore = new SemaphoreSlim(1);
 
             _serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
             _serializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
@@ -45,48 +41,21 @@
 
         public async Task<DaxFormatterResponse?> FormatAsync(DaxFormatterSingleRequest request, CancellationToken cancellationToken)
         {
-#if NETSTANDARD
-            await _formatSemaphore.WaitAsync().ConfigureAwait(false);
-#elif NET6_0_OR_GREATER
-            await _formatSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-#endif
-            try
-            {
-                request.CallerApp = _application;
-                request.CallerVersion = _version;
+            request.CallerApp = _application;
+            request.CallerVersion = _version;
 
-                var message = await FormatImplAsync(request, cancellationToken).ConfigureAwait(false);
-                var result = JsonSerializer.Deserialize<DaxFormatterResponse>(message, _serializerOptions);
-
-                return result;
-            }
-            finally
-            {
-                _formatSemaphore.Release();
-            }
+            var message = await FormatImplAsync(request, cancellationToken).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<DaxFormatterResponse>(message, _serializerOptions);
         }
 
         public async Task<IReadOnlyList<DaxFormatterResponse>> FormatAsync(DaxFormatterMultipleRequest request, CancellationToken cancellationToken)
         {
-#if NETSTANDARD
-            await _formatSemaphore.WaitAsync().ConfigureAwait(false);
-#elif NET6_0_OR_GREATER
-            await _formatSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-#endif
-            try
-            {
-                request.CallerApp = _application;
-                request.CallerVersion = _version;
+            request.CallerApp = _application;
+            request.CallerVersion = _version;
 
-                var message = await FormatImplAsync(request, cancellationToken).ConfigureAwait(false);
-                var result = JsonSerializer.Deserialize<IReadOnlyList<DaxFormatterResponse>>(message, _serializerOptions);
-
-                return result ?? Array.Empty<DaxFormatterResponse>();
-            }
-            finally
-            {
-                _formatSemaphore.Release();
-            }
+            var message = await FormatImplAsync(request, cancellationToken).ConfigureAwait(false);
+            var result = JsonSerializer.Deserialize<IReadOnlyList<DaxFormatterResponse>>(message, _serializerOptions);
+            return result ?? Array.Empty<DaxFormatterResponse>();
         }
 
         private async Task<string> FormatImplAsync<T>(T request, CancellationToken cancellationToken) where T : DaxFormatterRequest
@@ -99,20 +68,16 @@
             using var content = new StringContent(json, Encoding.UTF8, MediaTypeNamesApplicationJson);
             using var response = await _httpClient.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-#if NETSTANDARD
-            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#elif NET6_0_OR_GREATER
-            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-#endif
-            using var reader = new StreamReader(stream);
-            var message = reader.ReadToEnd();
 
-            return message;
+#if NETSTANDARD
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#elif NET6_0_OR_GREATER
+            return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
         }
 
         public void Dispose()
         {
-            _formatSemaphore.Dispose();
             _httpClient.Dispose();
         }
     }

--- a/src/Dax.Formatter/Client/Http/DaxFormatterHttpClient.cs
+++ b/src/Dax.Formatter/Client/Http/DaxFormatterHttpClient.cs
@@ -18,16 +18,11 @@
         private const string MediaTypeNamesApplicationJson = "application/json";
         private const int DaxFormatterTimeoutSeconds = 60;
 
-        private readonly HashSet<HttpStatusCode> _locationChangedStatusCodes;
         private readonly JsonSerializerOptions _serializerOptions;
-        private readonly SemaphoreSlim _initializeServiceUriSemaphore;
         private readonly SemaphoreSlim _formatSemaphore;
         private readonly HttpClient _httpClient;
         private readonly string? _application;
         private readonly string? _version;
-
-        private Uri? _daxTextFormatSingleServiceUri;
-        private Uri? _daxTextFormatMultiServiceUri;
 
         public DaxFormatterHttpClient(string? application, string? version)
         {
@@ -42,23 +37,10 @@
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNamesApplicationJson));
             _httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue(nameof(DecompressionMethods.GZip)));
             
-            _initializeServiceUriSemaphore = new SemaphoreSlim(1);
             _formatSemaphore = new SemaphoreSlim(1);
 
             _serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
             _serializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
-            
-            _locationChangedStatusCodes = new HashSet<HttpStatusCode>
-            {
-                HttpStatusCode.Moved,
-                HttpStatusCode.MovedPermanently,
-                HttpStatusCode.Found,
-                HttpStatusCode.Redirect,
-                HttpStatusCode.RedirectMethod,
-                HttpStatusCode.SeeOther,
-                HttpStatusCode.RedirectKeepVerb,
-                HttpStatusCode.TemporaryRedirect
-            };
         }
 
         public async Task<DaxFormatterResponse?> FormatAsync(DaxFormatterSingleRequest request, CancellationToken cancellationToken)
@@ -112,7 +94,7 @@
             cancellationToken.ThrowIfCancellationRequested();
 
             var json = JsonSerializer.Serialize(request, _serializerOptions);
-            var uri = await GetServiceUriAsync(request, cancellationToken).ConfigureAwait(false);
+            var uri = request.DaxTextFormatUri;
 
             using var content = new StringContent(json, Encoding.UTF8, MediaTypeNamesApplicationJson);
             using var response = await _httpClient.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
@@ -128,97 +110,8 @@
             return message;
         }
 
-        private async Task<Uri> GetServiceUriAsync(DaxFormatterRequest request, CancellationToken cancellationToken)
-        {
-            if (request is DaxFormatterMultipleRequest)
-            {
-                if (_daxTextFormatMultiServiceUri == null)
-                    _daxTextFormatMultiServiceUri = await InitializeMultiServiceUriAsync().ConfigureAwait(false);
-
-                return _daxTextFormatMultiServiceUri;
-            }
-            else if (request is DaxFormatterSingleRequest)
-            {
-                if (_daxTextFormatSingleServiceUri == null)
-                    _daxTextFormatSingleServiceUri = await InitializeSingleServiceUriAsync().ConfigureAwait(false);
-
-                return _daxTextFormatSingleServiceUri;
-            }
-            else
-            {
-                throw new NotSupportedException($"Uri not supported for { request.GetType().Name } request");
-            }
-
-            async Task<Uri> InitializeSingleServiceUriAsync()
-            {
-                if (_daxTextFormatSingleServiceUri == null)
-                {
-                    await _initializeServiceUriSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
-                    try
-                    {
-                        if (_daxTextFormatSingleServiceUri == null)
-                        {
-                            using var response = await _httpClient.GetAsync(request.DaxTextFormatUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                            var uri = request.DaxTextFormatUri;
-
-                            if (_locationChangedStatusCodes.Contains(response.StatusCode) && response.Headers.Location != null)
-                            {
-                                uri = response.Headers.Location;
-                            }
-                            else
-                            {
-                                response.EnsureSuccessStatusCode();
-                            }
-
-                            _daxTextFormatSingleServiceUri = uri;
-                        }
-                    }
-                    finally
-                    {
-                        _initializeServiceUriSemaphore.Release();
-                    }
-                }
-
-                return _daxTextFormatSingleServiceUri;
-            }
-
-            async Task<Uri> InitializeMultiServiceUriAsync()
-            {
-                if (_daxTextFormatMultiServiceUri == null)
-                {
-                    await _initializeServiceUriSemaphore.WaitAsync(CancellationToken.None).ConfigureAwait(false);
-                    try
-                    {
-                        if (_daxTextFormatMultiServiceUri == null)
-                        {
-                            using var response = await _httpClient.GetAsync(request.DaxTextFormatUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                            var uri = request.DaxTextFormatUri;
-
-                            if (_locationChangedStatusCodes.Contains(response.StatusCode) && response.Headers.Location != null)
-                            {
-                                uri = response.Headers.Location;
-                            }
-                            else
-                            {
-                                response.EnsureSuccessStatusCode();
-                            }
-
-                            _daxTextFormatMultiServiceUri = uri;
-                        }
-                    }
-                    finally
-                    {
-                        _initializeServiceUriSemaphore.Release();
-                    }
-                }
-
-                return _daxTextFormatMultiServiceUri;
-            }
-        }
-
         public void Dispose()
         {
-            _initializeServiceUriSemaphore.Dispose();
             _formatSemaphore.Dispose();
             _httpClient.Dispose();
         }

--- a/src/Dax.Formatter/Client/Http/DaxFormatterHttpClientMessageHandler.cs
+++ b/src/Dax.Formatter/Client/Http/DaxFormatterHttpClientMessageHandler.cs
@@ -7,7 +7,6 @@
     {
         public DaxFormatterHttpClientMessageHandler()
         {
-            AllowAutoRedirect = false;
             AutomaticDecompression = DecompressionMethods.GZip;
         }
     }

--- a/src/Dax.Formatter/Models/DaxFormatterMultipleRequest.cs
+++ b/src/Dax.Formatter/Models/DaxFormatterMultipleRequest.cs
@@ -13,7 +13,7 @@
             return request;
         }
 
-        internal override Uri DaxTextFormatUri { get; } = new Uri("https://www.daxformatter.com/api/daxformatter/daxtextformatmulti"); 
+        internal override Uri DaxTextFormatUri { get; } = new Uri("https://api.daxformatter.com/api/daxtextformatmulti");
  
         public List<string> Dax { get; set; } = new List<string>();
     }

--- a/src/Dax.Formatter/Models/DaxFormatterSingleRequest.cs
+++ b/src/Dax.Formatter/Models/DaxFormatterSingleRequest.cs
@@ -13,7 +13,7 @@
             return request;
         }
 
-        internal override Uri DaxTextFormatUri { get; } = new Uri("https://www.daxformatter.com/api/daxformatter/daxtextformat");
+        internal override Uri DaxTextFormatUri { get; } = new Uri("https://api.daxformatter.com/api/daxtextformat");
 
         public string? Dax { get; set; }
     }


### PR DESCRIPTION
This pull request updates the API endpoints used for formatting requests switching to the new API domain.

### API Endpoint Updates

* Updated the DAX formatter API endpoints in `DaxFormatterSingleRequest` and `DaxFormatterMultipleRequest` to use the new `https://api.daxformatter.com` domain instead of `https://www.daxformatter.com`.

### Refactoring and Simplification

* Removed the use of semaphores (`SemaphoreSlim`) and related logic for synchronizing service URI initialization. Now, the service URI is taken directly from the request object.
* Eliminated custom handling for HTTP redirect status codes, as well as the associated logic for following redirects.
* Simplified the reading of HTTP responses by removing the use of streams and reading the response content as a string directly.
* Removed the use of a formatting semaphore to serialize calls to the formatter, allowing concurrent formatting requests.

### HTTP Client Handler Change

* Stopped explicitly disabling auto-redirects in the custom HTTP client handler by removing `AllowAutoRedirect = false;`.