### PR TITLE
Remove .NET 6 target framework, add .NET 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     open-pull-requests-limit: 10
     assignees:
     - "albertospelta"
+    ignore:
+      - dependency-name: "Microsoft.NET.Test.Sdk"
+      - dependency-name: "xunit"
+      - dependency-name: "xunit.runner.visualstudio"
+      - dependency-name: "coverlet.collector"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            6.0.x
           global-json-file: global.json
       - name: restore
         run: dotnet restore ./src

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/Dax.Formatter.Tests/Dax.Formatter.Tests.csproj
+++ b/src/Dax.Formatter.Tests/Dax.Formatter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Dax.Formatter/Dax.Formatter.csproj
+++ b/src/Dax.Formatter/Dax.Formatter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -45,8 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-  </ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="10.0.9" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> </ItemGroup>
 
   <PropertyGroup>
     <DefineConstants>$(AdditionalConstants)</DefineConstants>
@@ -55,11 +54,11 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <AssemblyTitle>Dax.Formatter .NET Standard 2.0</AssemblyTitle>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <AssemblyTitle>Dax.Formatter .NET 6.0</AssemblyTitle>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <AssemblyTitle>Dax.Formatter .NET 8.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <AssemblyTitle>Dax.Formatter .NET 10.0</AssemblyTitle>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the project to support .NET 10.0, removes .NET 6.0 support, and updates related dependencies and configuration files accordingly. The main changes focus on upgrading the SDK, updating target frameworks, and adjusting CI and dependency management to align with these updates.

**.NET SDK and Target Framework Upgrades:**

* Updated the SDK version in `global.json` to `10.0.300` to use .NET 10.0 for builds.
* Updated target frameworks to include `net10.0` and remove `net6.0`.
* Updated assembly title properties to add `.NET 10.0` and remove `.NET 6.0` in `Dax.Formatter.csproj`.

**Dependency and Package Updates:**

* Upgraded `System.Text.Json` package for `netstandard2.0` from version `8.0.5` to `10.0.9` in `Dax.Formatter.csproj`.

**CI and Dependency Management Adjustments:**

* Updated `.github/dependabot.yml` to ignore updates for several test-related dependencies.