### PR TITLE
Switch NuGet publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -36,8 +37,14 @@ jobs:
       - name: pack
         run: dotnet pack ./src/Dax.Formatter/Dax.Formatter.csproj --configuration Release --no-build --output ./artifacts
 
-      - name: push to nuget.org
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: nuget login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: nuget push
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: create github release
         env:


### PR DESCRIPTION
Replace NUGET_API_KEY secret with NuGet/login@v1 OIDC-based keyless publishing.