### PR TITLE
Fix nuget push path: use explicit filename instead of glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           user: ${{ secrets.NUGET_USER }}
 
       - name: nuget push
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "./artifacts/Dax.Formatter.${{ steps.nbgv.outputs.NuGetPackageVersion }}.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: create github release
         env:


### PR DESCRIPTION
dotnet nuget push does not expand glob patterns on Windows/PowerShell. Replace ./artifacts/*.nupkg with the exact filename derived from the nbgv version output.