### PR TITLE
Fix npm steps in publish-mcp.yml

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           global-json-file: global.json
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+
       - uses: dotnet/nbgv@v0.4
         id: nbgv
         with:
@@ -37,13 +44,6 @@ jobs:
       - name: test
         working-directory: mcp
         run: npm test
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: npm
-          cache-dependency-path: mcp/package-lock.json
 
       # Stamp the Nerdbank.GitVersioning version into package.json
       - name: set version


### PR DESCRIPTION
Move actions/setup-node ahead of npm ci/build/test so the pinned Node 20 is actually used for them and the npm cache is restored before install, matching the order in ci-mcp.yml.